### PR TITLE
Use camel case in template arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ The function `pontella::parse` has the signature:
 namespace pontella {
     /// parse turns argc and argv into parsed arguments and options.
     /// If numberOfArguments is negative, the number of arguments is unlimited.
-    command_t parse(
+    command parse(
         int argc,
         char* argv[],
         int64_t number_of_arguments,
-        std::initializer_list<label_t> options,
-        std::initializer_list<label_t> flags);
+        std::initializer_list<label> options,
+        std::initializer_list<label> flags);
 }
 ```
 
@@ -44,22 +44,22 @@ namespace pontella {
 - `options` lists the available options (named arguments with a parameter) and their aliases (each option can have any number of aliases).
 - `flags` lists the available flags (named arguments without parameter) and their aliases (each flag can have any number of aliases).
 
-The type `pontella::label_t` represents an option or a flag, and is defined as:
+The type `pontella::label` represents an option or a flag, and is defined as:
 ```cpp
 namespace pontella {
-    /// label_t represents an option or flag name, and its aliases.
-    struct label_t {
+    /// label represents an option or flag name, and its aliases.
+    struct label {
         std::string name;
         std::unordered_set<std::string> aliases;
     };
 }
 ```
 
-The returned `pontella::command_t` is defined by:
+The returned `pontella::command` is defined by:
 ```cpp
 namespace pontella {
-    /// command_t contains parsed arguments, options and flags.
-    struct command_t {
+    /// command contains parsed arguments, options and flags.
+    struct command {
 
         /// arguments contains the positional arguments given to the program.
         std::vector<std::string> arguments;
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
         0,
         {},
         {},
-        [](pontella::command_t) -> int { return 0; });
+        [](pontella::command) -> int { return 0; });
 }
 ```
 
@@ -137,15 +137,15 @@ The `pontella::main` function has the signature:
 ```cpp
 namespace pontella {
     /// main wraps error handling and message display.
-    template <typename handle_command_t>
+    template <typename HandleCommand>
     inline int main(
         std::initializer_list<std::string> lines,
         int argc,
         char* argv[],
         int64_t number_of_arguments,
-        std::initializer_list<label_t> options,
-        std::initializer_list<label_t> flags,
-        handle_command_t handle_command);
+        std::initializer_list<label> options,
+        std::initializer_list<label> flags,
+        HandleCommand handle_command);
 }
 ```
 
@@ -155,14 +155,14 @@ namespace pontella {
 - `number_of_arguments` is the expected number of positional arguments. If the incorrect number of arguments is passed to the program, `pontella::parse` will throw an exception. To allow any number of arguments, set `number_of_arguments` to `-1`.
 - `options` lists the available options (named arguments with a parameter) and their aliases (each option can have any number of aliases).
 - `flags` lists the available flags (named arguments without parameter) and their aliases (each flag can have any number of aliases). The flag `help` (with alias `h`) is added internally before calling `pontella::parse`.
-- `handle_command` must be compatible with the expression `handle_command(pontella::command_t)` returning an `int`.
+- `handle_command` must be compatible with the expression `handle_command(pontella::command)` returning an `int`.
 
 More control can be achieved with manual error handling:
 ```cpp
 #include "../third_party/pontella/source/pontella.hpp"
 
 int main(int argc, char* argv[]) {
-    pontella::label_t help{"help", {"h"}};
+    pontella::label help{"help", {"h"}};
     auto show_help = false;
     try {
         const auto command = pontella::parse(argc, argv, 1, {{"verbose", {"v"}}}, {help});
@@ -198,7 +198,7 @@ namespace pontella {
     /// test determines wether the given flag was used.
     /// It is meant to be used to hide the error message when a specific flag (such as help) is given.
     /// This method does not work with options.
-    bool test(int argc, char* argv[], const label_t& flag);
+    bool test(int argc, char* argv[], const label& flag);
 }
 ```
 

--- a/source/pontella.hpp
+++ b/source/pontella.hpp
@@ -12,8 +12,8 @@
 /// pontella is a command  line parser.
 namespace pontella {
 
-    /// command_t contains parsed arguments, options and flags.
-    struct command_t {
+    /// command contains parsed arguments, options and flags.
+    struct command {
         /// arguments contains the positionnal arguments given to the program.
         std::vector<std::string> arguments;
 
@@ -24,8 +24,8 @@ namespace pontella {
         std::unordered_set<std::string> flags;
     };
 
-    /// label_t represents an option or flag name, and its aliases.
-    struct label_t {
+    /// label represents an option or flag name, and its aliases.
+    struct label {
         std::string name;
         std::unordered_set<std::string> aliases;
     };
@@ -54,7 +54,7 @@ namespace pontella {
     /// parse turns argc and argv into parsed arguments and options.
     /// If number_of_arguments is negative, the number of arguments is unlimited.
     template <typename option_iterator, typename flag_iterator>
-    inline command_t parse(
+    inline command parse(
         int argc,
         char* argv[],
         int64_t number_of_arguments,
@@ -94,7 +94,7 @@ namespace pontella {
                 }
             }
         }
-        command_t command;
+        command command;
         for (auto index = 1; index < argc; ++index) {
             const std::string element(argv[index]);
             if (element[0] == '-') {
@@ -175,37 +175,37 @@ namespace pontella {
         return command;
     }
     template <typename option_iterator>
-    inline command_t parse(
+    inline command parse(
         int argc,
         char* argv[],
         int64_t number_of_arguments,
         option_iterator options_begin,
         option_iterator options_end,
-        std::initializer_list<label_t> flags) {
+        std::initializer_list<label> flags) {
         return parse(argc, argv, number_of_arguments, options_begin, options_end, flags.begin(), flags.end());
     }
     template <typename flag_iterator>
-    inline command_t parse(
+    inline command parse(
         int argc,
         char* argv[],
         int64_t number_of_arguments,
-        std::initializer_list<label_t> options,
+        std::initializer_list<label> options,
         flag_iterator flags_begin,
         flag_iterator flags_end) {
         return parse(argc, argv, number_of_arguments, options.begin(), options.end(), flags_begin, flags_end);
     }
-    inline command_t parse(
+    inline command parse(
         int argc,
         char* argv[],
         int64_t number_of_arguments,
-        std::initializer_list<label_t> options,
-        std::initializer_list<label_t> flags) {
+        std::initializer_list<label> options,
+        std::initializer_list<label> flags) {
         return parse(argc, argv, number_of_arguments, options.begin(), options.end(), flags.begin(), flags.end());
     }
 
     /// test determines wether the given flag was used.
     /// It can be used to hide the error message when a specific flag is present.
-    inline bool test(int argc, char* argv[], const label_t& flag) {
+    inline bool test(int argc, char* argv[], const label& flag) {
         std::unordered_set<std::string> patterns;
         validate(flag.name, false, true);
         patterns.insert(std::string("-") + flag.name);
@@ -226,18 +226,18 @@ namespace pontella {
     }
 
     /// main wraps error handling and message display.
-    template <typename handle_command_t>
+    template <typename HandleCommand>
     inline int main(
         std::initializer_list<std::string> lines,
         int argc,
         char* argv[],
         int64_t number_of_arguments,
-        std::initializer_list<label_t> options,
-        std::initializer_list<label_t> flags,
-        handle_command_t handle_command) {
-        const label_t help{"help", {"h"}};
+        std::initializer_list<label> options,
+        std::initializer_list<label> flags,
+        HandleCommand handle_command) {
+        const label help{"help", {"h"}};
         try {
-            std::vector<label_t> flags_with_help(flags);
+            std::vector<label> flags_with_help(flags);
             flags_with_help.push_back(help);
             const auto command =
                 parse(argc, argv, number_of_arguments, options, flags_with_help.begin(), flags_with_help.end());

--- a/test/pontella.cpp
+++ b/test/pontella.cpp
@@ -188,7 +188,7 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command_t) -> int { return 0; })
+                [](pontella::command) -> int { return 0; })
             == 0);
     }
     for (const auto& option : {"--help", "-help", "--h", "-h"}) {
@@ -201,7 +201,7 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command_t) -> int { return 0; })
+                [](pontella::command) -> int { return 0; })
             == 1);
     }
     {
@@ -214,7 +214,7 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command_t) -> int {
+                [](pontella::command) -> int {
                     throw std::runtime_error("This program always errors");
                     return 0;
                 })


### PR DESCRIPTION
Also, avoid _t after types