### PR TITLE
handle_command must now return void

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ int main(int argc, char* argv[]) {
         0,
         {},
         {},
-        [](pontella::command) -> int { return 0; });
+        [](pontella::command command) {
+            // your application goes there
+        });
 }
 ```
 
@@ -155,7 +157,7 @@ namespace pontella {
 - `number_of_arguments` is the expected number of positional arguments. If the incorrect number of arguments is passed to the program, `pontella::parse` will throw an exception. To allow any number of arguments, set `number_of_arguments` to `-1`.
 - `options` lists the available options (named arguments with a parameter) and their aliases (each option can have any number of aliases).
 - `flags` lists the available flags (named arguments without parameter) and their aliases (each flag can have any number of aliases). The flag `help` (with alias `h`) is added internally before calling `pontella::parse`.
-- `handle_command` must be compatible with the expression `handle_command(pontella::command)` returning an `int`.
+- `handle_command` must be compatible with the expression `handle_command(pontella::command)`.
 
 More control can be achieved with manual error handling:
 ```cpp

--- a/source/pontella.hpp
+++ b/source/pontella.hpp
@@ -242,7 +242,8 @@ namespace pontella {
             const auto command =
                 parse(argc, argv, number_of_arguments, options, flags_with_help.begin(), flags_with_help.end());
             if (command.flags.find("help") == command.flags.end()) {
-                return handle_command(command);
+                handle_command(command);
+                return 0;
             }
         } catch (const std::exception& exception) {
             if (!test(argc, argv, help)) {

--- a/test/pontella.cpp
+++ b/test/pontella.cpp
@@ -188,7 +188,7 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command) -> int { return 0; })
+                [](pontella::command) {})
             == 0);
     }
     for (const auto& option : {"--help", "-help", "--h", "-h"}) {
@@ -201,7 +201,7 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command) -> int { return 0; })
+                [](pontella::command) {})
             == 1);
     }
     {
@@ -214,9 +214,8 @@ TEST_CASE("Test the main wrapper", "[main]") {
                 0,
                 {},
                 {},
-                [](pontella::command) -> int {
+                [](pontella::command) {
                     throw std::runtime_error("This program always errors");
-                    return 0;
                 })
             == 1);
     }


### PR DESCRIPTION
More complex use-cases should use the lower-level pontella::parse.